### PR TITLE
fix bug with ssl checking

### DIFF
--- a/domain_ownership_checker.gemspec
+++ b/domain_ownership_checker.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |gem|
   gem.name          = 'domain_ownership_checker'
-  gem.version       = '0.0.1'
+  gem.version       = '0.0.3'
   gem.date          = '2017-10-18'
   gem.summary       = 'Domain Ownership Checker'
   gem.description   = 'Checks domain ownership through a text file and DNS CNAME-record'

--- a/lib/domain_ownership_checker/providers/text_file_provider.rb
+++ b/lib/domain_ownership_checker/providers/text_file_provider.rb
@@ -11,7 +11,6 @@ class DomainOwnershipChecker
       attr_reader :filename
 
       require 'openssl'
-      OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
 
       def initialize(options)
         super(options)
@@ -36,7 +35,7 @@ class DomainOwnershipChecker
         require 'net/http'
 
         uri = URI(location)
-        Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', verify_ssl: false) do |http|
           request = Net::HTTP::Get.new uri
           response = http.request(request)
 


### PR DESCRIPTION
в общем ругается на эту строчку. потенциально дыра. сделал по рекомендации варнинга:
```
WARNING: OpenSSL::SSL::VERIFY_PEER == OpenSSL::SSL::VERIFY_NONE
This dangerous monkey patch leaves you open to MITM attacks!
Try passing :verify_ssl => false instead.
```